### PR TITLE
Fix/repair source link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,14 +21,17 @@ It is possible to install in your store either by using App Store or the VTEX IO
 1. Access the **Apps** section in your account's admin page and look for the Tawk.to box;
 2. Then, click on the **Install** button;
 3. You'll see a warning message about needing to enter the necessary configurations. Scroll down and type in your tawk.to's **Property ID**.
-4. Click on **Save**.
+6. Then, configure on Tawk.to a Chat widget and insert the Direct Chat link in the **Direct Chat Link** box.
+5. Click on **Save**.
+
 
 ### Using VTEX IO Toolbelt
 
 1. In your terminal, [install](https://vtex.io/docs/recipes/development/installing-an-app/) the `vtex.tawk-to@0.x` app. You can confirm that the app has now been installed by running `vtex ls` again.
 2. Access the **Apps** section in your account's admin page and look for the Tawk.to box. Once you find it, click on it.
 3. Fill with your tawk.to's **Property ID**.
-4. Click on **Save**.
+6. Then, configure on Tawk.to a Chat widget and insert the Direct Chat link in the **Direct Chat Link** box.
+5. Click on **Save**.
 
 <!-- DOCS-IGNORE:start -->
 ## Contributors ✨

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "tawk-to",
   "vendor": "vtex",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "title": "Tawk.to",
   "description": "Message your customers, they'll love you for it.",
   "billingOptions": {

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,10 @@
       "id": {
         "title": "Property ID",
         "type": "string"
+      },
+      "link": {
+        "title": "Direct Chat Link",
+        "type": "string"
       }
     }
   },

--- a/pixel/body.html
+++ b/pixel/body.html
@@ -1,14 +1,15 @@
 <script type="text/javascript">
   var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
   (function(){
-    var propertyId = "{{settings.id}}";
-    if (!propertyId) {
-      console.error('Warning: No Property ID is defined. Please configure it in the apps admin.');
+    var propertyId = "{{settings.id}}", link = "{{settings.link}}", linkId;
+    if (!propertyId || !link) {
+      console.error('Warning: No Property ID or Chat Direct Link is defined. Please configure it in the apps admin.');
       return
     }
+    linkId = link.substring(link.lastIndexOf('%') + 3);
     var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
     s1.async=true;
-    s1.src='https://embed.tawk.to/'+propertyId+'/default';
+    s1.src='https://embed.tawk.to/'+propertyId+'/'+linkId;
     s1.charset='UTF-8';
     s1.setAttribute('crossorigin','*');
     s0.parentNode.insertBefore(s1,s0);


### PR DESCRIPTION
**What problem is this solving?**

Recently, Tawk.to changed the source link that renders their chat app on the webstore.

Previously, the link was composed of:
'https://embed.tawk.to/' + propertyId + '/default'

Now, it is composed of:
'https://embed.tawk.to/' + propertyId + '/' + linkId
- where linkId is the string found in the Direct Chat Link

![image](https://user-images.githubusercontent.com/74401038/123517687-18dfbd80-d6ab-11eb-9254-b092f32fd227.png)


**How should this be manually tested?**
https://danieltest--melimeloparis.myvtex.com/?__bindingAddress=www.melimeloparis.ro/



**Screenshots or example usage:**
<img width="1440" alt="Screenshot 2021-06-26 at 18 01 21" src="https://user-images.githubusercontent.com/74401038/123517699-28f79d00-d6ab-11eb-80fb-9b7249b07f81.png">